### PR TITLE
stop search thread before custom UCI command

### DIFF
--- a/UCIService.h
+++ b/UCIService.h
@@ -412,6 +412,7 @@ class UCIService {
             std::istringstream line_stream{line};
             line_stream >> word;
             if (command_handlers_.find(word) != command_handlers_.end()) {
+                stop_search();
                 command_handlers_[word](line_stream);
             } else if (word == "uci") {
                 uci_handler();


### PR DESCRIPTION
Stop the search-thread when a custom command is given. This to prevent that the position-object is changed while by the search-thread or by the custom command as that would wreck havoc.

An alternative approach would be exporting a "stop search thread and wait for it to terminate"-method.